### PR TITLE
Don't enforce utf-8 in accept headers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    paychex (0.1.2)
+    paychex (0.2.1)
       addressable
       faraday
       faraday_middleware
@@ -62,4 +62,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.4
+   2.4.4

--- a/lib/paychex/connection.rb
+++ b/lib/paychex/connection.rb
@@ -8,7 +8,7 @@ module Paychex
     def connection
       options = {
         headers: {
-          'Accept' => "application/#{format}; charset=utf-8",
+          'Accept' => "application/#{format}",
           'User-Agent' => user_agent
         },
         proxy: proxy,

--- a/lib/paychex/version.rb
+++ b/lib/paychex/version.rb
@@ -1,3 +1,3 @@
 module Paychex
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
Updating accept headers to just include the type we need and not enforcing the utf-8 charset fixes the `API-2` errors