### PR TITLE
feat: WS-31695: Paychex | Add pagination support on the paychex gem so that companies can be fetch few at a time

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    paychex (0.3.3)
+    paychex (0.3.4)
       addressable
       faraday
       faraday_middleware

--- a/lib/paychex/client/companies.rb
+++ b/lib/paychex/client/companies.rb
@@ -3,8 +3,43 @@ module Paychex
     module Companies
       # Get a list of all the linked companies
       # This will be unavailable once we have 200+ linked companies
-      def linked_companies
-        get('companies')
+      def linked_companies(options)
+        limit = options[:limit] || 100
+        initial_opts = { limit: limit, offset: 0 }
+
+        # first API call to get companies on first page. This helps to determine total no. of pages
+        response = get_api('companies', initial_opts)
+        response_content = []
+
+        if response && response.body
+          companies_count = response.body.fetch('metadata').fetch('pagination').fetch('total')
+
+          return response_content unless companies_count
+
+          no_of_pages = (companies_count.to_f / limit).ceil
+
+          companies_content = response.body.fetch('content').to_a
+          companies_content = companies_content.select { |c| c['hasPermission'] } if companies_content
+
+          response_content += companies_content
+
+          # next API calls
+          if no_of_pages >= 2
+            (2..no_of_pages).each do |page|
+              opts = { limit: limit, offset: (page - 1) * limit }
+              next_response = get_api('companies', opts)
+
+              break unless next_response && next_response.body
+
+              companies_content = next_response.body.fetch('content').to_a
+              companies_content = companies_content.select { |c| c['hasPermission'] } if companies_content
+
+              response_content += companies_content
+            end
+          end
+        end
+
+        response_content
       end
 
       # Get profile of a linked company
@@ -83,6 +118,15 @@ module Paychex
         end
         ret['message'] = 'unsupported'
         ret
+      end
+    end
+
+    # Call API with pagination parameters
+    def get_api(endpoint, options)
+      begin
+        get(endpoint, options)
+      rescue => e
+        nil
       end
     end
   end

--- a/lib/paychex/client/companies.rb
+++ b/lib/paychex/client/companies.rb
@@ -116,6 +116,8 @@ module Paychex
       end
     end
 
+    private
+
     def companies(options)
       begin
         get('companies', options)

--- a/lib/paychex/client/companies.rb
+++ b/lib/paychex/client/companies.rb
@@ -2,41 +2,36 @@ module Paychex
   class Client
     module Companies
       # Get a list of all the linked companies
-      # This will be unavailable once we have 200+ linked companies
-      def linked_companies(options)
-        limit = options[:limit] || 100
-        initial_opts = { limit: limit, offset: 0 }
-
-        # first API call to get companies on first page. This helps to determine total no. of pages
-        response = get_api('companies', initial_opts)
+      def linked_companies
+        limit = per_page
+        opts = { limit: limit, offset: 0 }
         response_content = []
+        current_page = 1
 
-        if response && response.body
-          companies_count = response.body.fetch('metadata').fetch('pagination').fetch('total')
+        response = companies(opts)
 
-          return response_content unless companies_count
+        begin
+          while response && response.body
+            companies_count = response.body.fetch('metadata').fetch('pagination').fetch('total')
 
-          no_of_pages = (companies_count.to_f / limit).ceil
+            break unless companies_count
 
-          companies_content = response.body.fetch('content').to_a
-          companies_content = companies_content.select { |c| c['hasPermission'] } if companies_content
+            no_of_pages = (companies_count.to_f / limit).ceil
 
-          response_content += companies_content
+            companies_content = response.body.fetch('content').to_a
+            companies_content = companies_content.select { |c| c['hasPermission'] } if companies_content
+            response_content += companies_content
 
-          # next API calls
-          if no_of_pages >= 2
-            (2..no_of_pages).each do |page|
+            if current_page < no_of_pages
               opts = { limit: limit, offset: (page - 1) * limit }
-              next_response = get_api('companies', opts)
-
-              break unless next_response && next_response.body
-
-              companies_content = next_response.body.fetch('content').to_a
-              companies_content = companies_content.select { |c| c['hasPermission'] } if companies_content
-
-              response_content += companies_content
+              response = companies(opts)
+              current_page += 1
+            else
+              break
             end
           end
+        rescue StandardError => e
+          return response_content
         end
 
         response_content
@@ -121,10 +116,9 @@ module Paychex
       end
     end
 
-    # Call API with pagination parameters
-    def get_api(endpoint, options)
+    def companies(options)
       begin
-        get(endpoint, options)
+        get('companies', options)
       rescue => e
         nil
       end

--- a/lib/paychex/client/companies.rb
+++ b/lib/paychex/client/companies.rb
@@ -22,10 +22,10 @@ module Paychex
             companies_content = companies_content.select { |c| c['hasPermission'] } if companies_content
             response_content += companies_content
 
-            if current_page < no_of_pages
-              opts = { limit: limit, offset: (page - 1) * limit }
+            current_page += 1
+            if current_page <= no_of_pages
+              opts = { limit: limit, offset: (current_page - 1) * limit }
               response = companies(opts)
-              current_page += 1
             else
               break
             end

--- a/lib/paychex/configuration.rb
+++ b/lib/paychex/configuration.rb
@@ -23,7 +23,7 @@ module Paychex
     DEFAULT_ACCESS_TOKEN = nil
 
     # By default, return 20 resources per page when there is an pagination.
-    DEFAULT_PER_PAGE = 20
+    DEFAULT_PER_PAGE = 100
 
     # By default, don't set connection options.
     DEFAULT_CONNECTION_OPTIONS = {}

--- a/lib/paychex/version.rb
+++ b/lib/paychex/version.rb
@@ -1,3 +1,3 @@
 module Paychex
-  VERSION = '0.3.3'
+  VERSION = '0.3.4'
 end

--- a/spec/fixtures/companies/companies.json
+++ b/spec/fixtures/companies/companies.json
@@ -1,12 +1,19 @@
 {
   "metadata": {
-    "contentItemCount": 2
+    "contentItemCount": 2,
+    "pagination": {
+      "offset": 0,
+      "limit": 100,
+      "itemCount": 2,
+      "total": 2
+  }
   },
   "content": [
     {
       "companyId": "WWEMHMFU",
       "displayId": "62725201",
       "legalName": "SAMPLE CLIENT",
+      "hasPermission": true,
       "legalId": {
         "legalIdType": "INFL",
         "legalIdValue": "MISSING"
@@ -37,6 +44,7 @@
       "companyId": "RPELHMDU",
       "displayId": "98771491",
       "legalName": "SAMPLE CLIENT 2",
+      "hasPermission": false,
       "legalId": {
         "legalIdType": "INFL",
         "legalIdValue": "MISSING"

--- a/spec/fixtures/companies/companies.json
+++ b/spec/fixtures/companies/companies.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
-    "contentItemCount": 2,
+    "contentItemCount": 5,
     "pagination": {
       "offset": 0,
-      "limit": 100,
-      "itemCount": 2,
-      "total": 2
-  }
+      "limit": 5,
+      "itemCount": 10,
+      "total": 10
+    }
   },
   "content": [
     {
@@ -44,7 +44,7 @@
       "companyId": "RPELHMDU",
       "displayId": "98771491",
       "legalName": "SAMPLE CLIENT 2",
-      "hasPermission": false,
+      "hasPermission": true,
       "legalId": {
         "legalIdType": "INFL",
         "legalIdValue": "MISSING"
@@ -70,6 +70,45 @@
           "href": "https://sandbox.api.paychex.com/companies/RPELHMDU/workers"
         }
       ]
+    },
+    {
+      "companyId": "YPELHMDU",
+      "displayId": "98771492",
+      "legalName": "SAMPLE CLIENT 3",
+      "hasPermission": true,
+      "legalId": {
+        "legalIdType": "INFL",
+        "legalIdValue": "MISSING"
+      },
+      "communications": [
+        {
+          "type": "STREET_ADDRESS",
+          "usageType": "BUSINESS",
+          "streetLineOne": "121 ST. PARKS",
+          "city": "LUDIANA",
+          "postalCode": "385126",
+          "countrySubdivisionCode": "PB",
+          "countryCode": "IN"
+        }
+      ],
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://sandbox.api.paychex.com/companies/YPELHMDU"
+        },
+        {
+          "rel": "workers",
+          "href": "https://sandbox.api.paychex.com/companies/YPELHMDU/workers"
+        }
+      ]
+    },
+    {
+      "companyId": "YELHMDPU",
+      "hasPermission": false
+    },
+    {
+      "companyId": "TPELHERU",
+      "hasPermission": false
     }
   ],
   "links": [

--- a/spec/fixtures/companies/companies_page_two.json
+++ b/spec/fixtures/companies/companies_page_two.json
@@ -1,0 +1,93 @@
+{
+  "metadata": {
+    "contentItemCount": 5,
+    "pagination": {
+      "offset": 5,
+      "limit": 5,
+      "itemCount": 10,
+      "total": 10
+    }
+  },
+  "content": [
+    {
+      "companyId": "MDURPELH",
+      "displayId": "98771493",
+      "legalName": "SAMPLE CLIENT 6",
+      "hasPermission": true,
+      "legalId": {
+        "legalIdType": "INFL",
+        "legalIdValue": "MISSING"
+      },
+      "communications": [
+        {
+          "type": "STREET_ADDRESS",
+          "usageType": "BUSINESS",
+          "streetLineOne": "122 ST. PARKS",
+          "city": "LUDIANA",
+          "postalCode": "385127",
+          "countrySubdivisionCode": "PB",
+          "countryCode": "IN"
+        }
+      ],
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://sandbox.api.paychex.com/companies/MDURPELH"
+        },
+        {
+          "rel": "workers",
+          "href": "https://sandbox.api.paychex.com/companies/MDURPELH/workers"
+        }
+      ]
+    },
+    {
+      "companyId": "ELHRPMDU",
+      "displayId": "98771494",
+      "legalName": "SAMPLE CLIENT 7",
+      "hasPermission": true,
+      "legalId": {
+        "legalIdType": "INFL",
+        "legalIdValue": "MISSING"
+      },
+      "communications": [
+        {
+          "type": "STREET_ADDRESS",
+          "usageType": "BUSINESS",
+          "streetLineOne": "123 ST. PARKS",
+          "city": "LUDIANA",
+          "postalCode": "385128",
+          "countrySubdivisionCode": "PB",
+          "countryCode": "IN"
+        }
+      ],
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://sandbox.api.paychex.com/companies/ELHRPMDU"
+        },
+        {
+          "rel": "workers",
+          "href": "https://sandbox.api.paychex.com/companies/ELHRPMDU/workers"
+        }
+      ]
+    },
+    {
+      "companyId": "UULHMDPU",
+      "hasPermission": false
+    },
+    {
+      "companyId": "TPEHJERU",
+      "hasPermission": false
+    },
+    {
+      "companyId": "RWQJERU",
+      "hasPermission": false
+    }
+  ],
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://sandbox.api.paychex.com/companies/"
+    }
+  ]
+}

--- a/spec/paychex/client/companies_spec.rb
+++ b/spec/paychex/client/companies_spec.rb
@@ -1,18 +1,31 @@
 RSpec.describe 'Paychex' do
   describe 'companies' do
-    it 'linked_companies should return list' do
-      stub_get('companies?limit=100&offset=0').
+    before do
+      allow(Paychex).to receive(:per_page).and_return(5)
+
+      # Stub the first page of /companies API response
+      stub_get('companies?limit=5&offset=0').
         to_return(
           status: 200,
           body: fixture('companies/companies.json'),
           headers: { "Content-Type": "application/json"}
         )
+      
+      # Stub the second page of /companies API response
+      stub_get('companies?limit=5&offset=5').
+        to_return(
+          status: 200,
+          body: fixture('companies/companies_page_two.json'),
+          headers: { "Content-Type": "application/json"}
+        )
+    end
 
+    it 'linked_companies should return consolidated list of companies spread across multiple pages' do
       client = Paychex.client()
       client.access_token = '211fe7540e'
       linked_companies = client.linked_companies
 
-      expect(linked_companies.count).to be 1
+      expect(linked_companies.count).to be 5
       expect(linked_companies.first).to have_key('hasPermission')
       expect(linked_companies.first.fetch('hasPermission')).to be(true)
     end

--- a/spec/paychex/client/companies_spec.rb
+++ b/spec/paychex/client/companies_spec.rb
@@ -1,16 +1,20 @@
 RSpec.describe 'Paychex' do
   describe 'companies' do
     it 'linked_companies should return list' do
-      stub_get('companies').to_return(
-        body: fixture('companies/companies.json'),
-        headers: { content_type: 'application/json; charset=utf-8' }
-      )
+      stub_get('companies?limit=100&offset=0').
+        to_return(
+          status: 200,
+          body: fixture('companies/companies.json'),
+          headers: { "Content-Type": "application/json"}
+        )
+
       client = Paychex.client()
       client.access_token = '211fe7540e'
-      response = client.linked_companies
-      expect(response.status).to eq(200)
-      expect(response.body['metadata']['contentItemCount']).to be 2
-      expect(response.body['content'].count).to be 2
+      linked_companies = client.linked_companies
+
+      expect(linked_companies.count).to be 1
+      expect(linked_companies.first).to have_key('hasPermission')
+      expect(linked_companies.first.fetch('hasPermission')).to be(true)
     end
 
     it 'linked_company should return a specific company profile' do


### PR DESCRIPTION
- Updated `linked_companies` to query companies with pagination parameters and return the total company records